### PR TITLE
Add `memory.x` to dependent crates via `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}


### PR DESCRIPTION
This is an exact copy of the `build.rs` script included in the `f3`
crate[1]. Including this build script spares binary crates from having
to include `memory.x`, instead using it implicitly when making use of
the BSP crate.

[1]: https://github.com/japaric/f3/blob/master/build.rs


----

Note that I'm a complete noob regarding embedded Rust, so this change
may be ill-advised.