### PR TITLE
Use digital v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 **.sw*
 bloat_log*
 itm.txt
+.gdb_history

--- a/src/led.rs
+++ b/src/led.rs
@@ -113,20 +113,20 @@ ctor!(LD3, LD4, LD5, LD6);
 impl Led {
     /// Turns the LED off
     pub fn off(&mut self) {
-        self.pin.set_low().unwrap();
+        self.pin.set_low().ok();
     }
 
     /// Turns the LED on
     pub fn on(&mut self) {
-        self.pin.set_high().unwrap();
+        self.pin.set_high().ok();
     }
 
     /// Toggles the LED
     pub fn toggle(&mut self) {
         if let Ok(true) = self.pin.is_low() {
-            self.pin.set_high().unwrap();
+            self.pin.set_high().ok();
         } else {
-            self.pin.set_low().unwrap();
+            self.pin.set_low().ok();
         }
     }
 }

--- a/src/led.rs
+++ b/src/led.rs
@@ -113,20 +113,20 @@ ctor!(LD3, LD4, LD5, LD6);
 impl Led {
     /// Turns the LED off
     pub fn off(&mut self) {
-        self.pin.set_low();
+        self.pin.set_low().unwrap();
     }
 
     /// Turns the LED on
     pub fn on(&mut self) {
-        self.pin.set_high();
+        self.pin.set_high().unwrap();
     }
 
     /// Toggles the LED
     pub fn toggle(&mut self) {
         if let Ok(true) = self.pin.is_low() {
-            self.pin.set_high();
+            self.pin.set_high().unwrap();
         } else {
-            self.pin.set_low();
+            self.pin.set_low().unwrap();
         }
     }
 }


### PR DESCRIPTION
I've added calls to `unwrap()` when turning LEDs on and off to get rid off the warnings from digital v2.
Please let me know if that small addition of adding `.gdb_history` to `.gitignore` should go into a separate PR dealing with OpenOCD and the problems mentioned in #6.