### PR TITLE
Fix itm example

### DIFF
--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -1,15 +1,7 @@
 //! Sends "Hello, world!" through the ITM port 0
-//!
 //! ITM is much faster than semihosting. Like 4 orders of magnitude or so.
 //!
-//! **NOTE** Cortex-M0 chips don't support ITM.
-//!
-//! You'll have to connect the microcontroller's SWO pin to the SWD interface. Note that some
-//! development boards don't provide this option.
-//!
-//! You'll need [`itmdump`] to receive the message on the host plus you'll need to uncomment two
-//! `monitor` commands in the `.gdbinit` file.
-//!
+//! You'll need [`itmdump`] to receive the message on the host
 //! [`itmdump`]: https://docs.rs/itm/0.2.1/itm/
 //!
 //! ---

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -18,17 +18,28 @@
 #![no_std]
 
 extern crate panic_itm;
-extern crate stm32f407g_disc;
+extern crate stm32f407g_disc as board;
+extern crate embedded_hal as hal;
+
+use board::hal::prelude::*;
+use board::hal::stm32;
 
 use cortex_m::{iprintln, Peripherals};
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut p = Peripherals::take().unwrap();
-    let stim = &mut p.ITM.stim[0];
+	if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+	    // Constrain clock registers
+	    let mut rcc = p.RCC.constrain();
+	    // Configure clock to 168 MHz (i.e. the maximum) and freeze it
+	    rcc.cfgr.sysclk(168.mhz()).freeze();
 
-    iprintln!(stim, "Hello, world!");
+	    let mut itm = cp.ITM;
+	    let stim = &mut itm.stim[0];
+
+	    iprintln!(stim, "Hello, world!");
+	}
 
     loop {}
 }

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -23,7 +23,7 @@ use cortex_m_rt::entry;
 fn main() -> ! {
 	if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
 	    // Constrain clock registers
-	    let mut rcc = p.RCC.constrain();
+	    let rcc = p.RCC.constrain();
 	    // Configure clock to 168 MHz (i.e. the maximum) and freeze it
 	    rcc.cfgr.sysclk(168.mhz()).freeze();
 

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-v2.cfg]
 transport select hla_swd
 
 # increase working area to 64KB

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -23,10 +23,10 @@ set mem inaccessible-by-default off
 
 # monitor arm semihosting enable
 
-# # send captured ITM to the file itm.fifo
-# # (the microcontroller SWO pin must be connected to the programmer SWO pin)
-# # 16000000 must match the core clock frequency
-# monitor tpiu config internal itm.txt uart off 16000000
+# # send captured ITM to the file itm.txt
+# # (the programmer's SWO pin on the STM32F4DISCOVERY is hard-wired to PB3. Make sure not to use it for a different purpose!)
+# # 168000000 is the core clock frequency
+monitor tpiu config internal itm.txt uart off 168000000
 
 # # OR: make the microcontroller SWO pin output compatible with UART (8N1)
 # # 8000000 is the frequency of the SWO pin

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -14,9 +14,6 @@ break rust_begin_unwind
 # *try* to stop at the user entry point (it might be gone due to inlining)
 break main
 
-monitor arm semihosting enable
-
-
 # send captured ITM to the file itm.txt
 # (the programmer's SWO pin on the STM32F4DISCOVERY is hard-wired to PB3. Make sure not to use it for a different purpose!)
 # 168000000 is the core clock frequency

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -10,30 +10,25 @@ set backtrace limit 32
 break DefaultHandler
 break HardFault
 break rust_begin_unwind
-# # run the next few lines so the panic message is printed immediately
-# # the number needs to be adjusted for your panic handler
-# commands $bpnum
-# next 4
-# end
 
 # *try* to stop at the user entry point (it might be gone due to inlining)
 break main
 
-set mem inaccessible-by-default off
+monitor arm semihosting enable
 
-# monitor arm semihosting enable
 
-# # send captured ITM to the file itm.txt
-# # (the programmer's SWO pin on the STM32F4DISCOVERY is hard-wired to PB3. Make sure not to use it for a different purpose!)
-# # 168000000 is the core clock frequency
+# send captured ITM to the file itm.txt
+# (the programmer's SWO pin on the STM32F4DISCOVERY is hard-wired to PB3. Make sure not to use it for a different purpose!)
+# 168000000 is the core clock frequency
 monitor tpiu config internal itm.txt uart off 168000000
 
-# # OR: make the microcontroller SWO pin output compatible with UART (8N1)
-# # 8000000 is the frequency of the SWO pin
+
+# OR: make the microcontroller SWO (PB3) pin output compatible with UART (8N1)
+# 8000000 is the frequency of the SWO pin
 # monitor tpiu config external uart off 8000000 2000000
 
-# # enable ITM port 0
-monitor itm port 0 on
+# # enable ITM port 1
+monitor itm port 1 on
 
 load
 

--- a/openocd_program.sh
+++ b/openocd_program.sh
@@ -5,4 +5,4 @@ if (( $# != 1 )); then
         exit 1
 fi
 
-openocd -c "init" -c "targets" -c "reset halt" -c "program $1 verify reset exit"
+openocd -f openocd.cfg -c "init" -c "targets" -c "reset halt" -c "program $1 verify reset exit"


### PR DESCRIPTION
As mentioned in #6 the example wasn't working out of the box. I've trimmed the gdb config and some comments removing parts that weren't relevant for this crate, updated the code, and made sure OpenOCD and `openocd_program.sh` use the correct config file.

I've tested this on the STM32F4DISCOVERY board.