### PR TITLE
new example: dwt_elapsed_time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ readme = "README.md"
 [dependencies]
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
+cortex-m-semihosting = "0.3"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/examples/dwt_elapsed_time.rs
+++ b/examples/dwt_elapsed_time.rs
@@ -1,0 +1,70 @@
+#![no_main]
+#![no_std]
+
+// Use DWT (Debug Watch and Trace) module to measure elapsed time.
+// DWT has a 32-bit running counter that counts CPU clock cycles.
+// Benefit of using DWT to measure elapsed time is that, it doesn't require interrupts.
+
+use panic_halt as _;
+
+use stm32f407g_disc as board;
+
+use crate::board::{
+    hal::stm32,
+    hal::{delay::Delay, prelude::*},
+    led::{LedColor, Leds},
+};
+
+use cortex_m::peripheral::{Peripherals, DWT};
+
+use cortex_m_rt::entry;
+
+use cortex_m_semihosting::hprintln;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(p), Some(mut cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+        let gpiod = p.GPIOD.split();
+
+        cp.DWT.enable_cycle_counter();
+
+        // Initialize on-board LEDs
+        let mut leds = Leds::new(gpiod);
+
+        // Constrain clock registers
+        let rcc = p.RCC.constrain();
+
+        // Configure clock to 168 MHz (i.e. the maximum) and freeze it
+        let clocks = rcc.cfgr.sysclk(168.mhz()).freeze();
+
+        // Get delay provider
+        let mut delay = Delay::new(cp.SYST, clocks);
+
+        let begin_clock = DWT::get_cycle_count();
+
+        // delay for 0.1 second
+        delay.delay_ms(100_u16);
+        
+        let end_clock = DWT::get_cycle_count();
+        
+        // Calculate elapsed clock cycles
+        let elapsed_clocks = end_clock - begin_clock;
+
+        // Just to signal that time measurement is finished
+        leds[LedColor::Orange].on();
+        
+        hprintln!("{}", elapsed_clocks).unwrap();
+        
+        // Ensure that the measured clock cycles are within acceptable bounds
+        assert!(
+            elapsed_clocks >= (16_800_000 - 1_000)
+            && elapsed_clocks < (16_800_000 + 1_000)
+        );
+
+        loop {
+            continue;
+        }
+    }
+
+    panic!("Failed to access peripherals");
+}

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -14,6 +14,8 @@ break rust_begin_unwind
 # *try* to stop at the user entry point (it might be gone due to inlining)
 break main
 
+monitor arm semihosting enable
+
 # send captured ITM to the file itm.txt
 # (the programmer's SWO pin on the STM32F4DISCOVERY is hard-wired to PB3. Make sure not to use it for a different purpose!)
 # 168000000 is the core clock frequency


### PR DESCRIPTION
Hello :smiley: , 
I wrote a short example program that measures the elapsed time of a small task,
and tested that it works in my `stm32f407g-disc` board.

I thought maybe it could be added to the examples in this repo?
Please feel free to correct anything that you find awkward in this new example program.

P.S.
It seems that since DWT maintains a 32-bit counter, it has limited use in measuring elapsed time of a long-running task.. Should one use the `SysTick` timer to measure elapsed time of a long-running task?