### PR TITLE
minor typo fixes in comments

### DIFF
--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -17,7 +17,7 @@ fn main() -> ! {
         let gpiob = p.GPIOB.split();
         let rcc = p.RCC.constrain();
 
-        // Set up the clocks, going to fast exhibits some problem so let's take it slow for now
+        // Set up the clocks, going too fast exhibits some problem so let's take it slow for now
         let clocks = rcc.cfgr.sysclk(40.mhz()).freeze();
 
         // Set up the SCL pin of the I2C bus at PB6

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -17,7 +17,7 @@ fn main() -> ! {
         let gpiob = p.GPIOB.split();
         let rcc = p.RCC.constrain();
 
-        // Set up the clocks, going to fast exhibits some problem so let's take it slow for now
+        // Set up the clocks, going too fast exhibits some problem so let's take it slow for now
         let clocks = rcc.cfgr.sysclk(40.mhz()).freeze();
 
         // Set up the SCL pin of the I2C bus at PB6


### PR DESCRIPTION
* This PR contains trivial typo fixes: "going **to** fast" => "going **too** fast"

* P.S.
I wanted to say thank you for writing the example programs
`i2c_hal_ssd1306alphabeter.rs` & `i2c_hal_ssd1306helloworld.rs` ! :+1: 
I was able to run the examples on my board with my new ssd1306 display today :smiley_cat:
![image](https://user-images.githubusercontent.com/10286488/83331842-51be2080-a266-11ea-9d4e-2ce8324d6206.png)

 