### PR TITLE
Add support for onboard LIS302DL accelerometer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ version = "0.4.0"
 readme = "README.md"
 
 [dependencies]
+accelerometer = "0.11.0"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
+lis302dl = "0.1.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -29,7 +31,7 @@ version = "0.2"
 [dependencies.stm32f4xx-hal]
 default-features = false
 features = ["rt", "stm32f407"]
-version = "0.6"
+version = "0.8.2"
 
 [dev-dependencies]
 ssd1306 = "0.2"
@@ -43,3 +45,6 @@ debug = true
 debug = true
 lto = true
 opt-level = "s"
+
+[dependencies.panic-itm]
+version = "0.4.1"

--- a/examples/mems.rs
+++ b/examples/mems.rs
@@ -1,0 +1,78 @@
+#![no_main]
+#![no_std]
+
+use panic_itm as _;
+
+use stm32f407g_disc as board;
+
+use cortex_m_rt::entry;
+
+use board::hal::prelude::*;
+use board::hal::stm32;
+use board::led::{LedColor, Leds};
+
+use cortex_m::iprintln;
+use cortex_m::peripheral::Peripherals;
+
+use accelerometer::orientation::Tracker;
+use accelerometer::Accelerometer;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+        let gpioa = p.GPIOA.split();
+        let gpiod = p.GPIOD.split();
+        let gpioe = p.GPIOE.split();
+        let mut itm = cp.ITM;
+
+        // Initialize on-board LEDs
+        let mut leds = Leds::new(gpiod);
+
+        // Constrain clock registers
+        let rcc = p.RCC.constrain();
+
+        // Configure clock to 168 MHz (i.e. the maximum) and freeze it
+        let clocks = rcc.cfgr.sysclk(168.mhz()).freeze();
+
+        let mut accelerometer =
+            board::accelerometer::Accelerometer::new(gpioa, gpioe, p.SPI1, clocks);
+        let mut tracker = Tracker::new(0.2);
+
+        loop {
+            let acceleration = accelerometer.accel_norm().unwrap();
+            let orientation = tracker.update(acceleration);
+
+            iprintln!(
+                &mut itm.stim[0],
+                "received {:?} : {}, {}, {}",
+                orientation,
+                acceleration.x,
+                acceleration.y,
+                acceleration.z,
+            );
+
+            for led in leds.iter_mut() {
+                led.off();
+            }
+
+            // x+ orange
+            // x- blue
+            // y+ green
+            // y- red
+
+            if acceleration.x > 0.0 {
+                leds[LedColor::Orange].on();
+            } else {
+                leds[LedColor::Blue].on();
+            }
+
+            if acceleration.y > 0.0 {
+                leds[LedColor::Green].on();
+            } else {
+                leds[LedColor::Red].on();
+            }
+        }
+    }
+
+    loop {}
+}

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -1,0 +1,81 @@
+use accelerometer;
+use lis302dl;
+
+use crate::hal::gpio;
+use crate::hal::gpio::gpioa;
+use crate::hal::gpio::gpioe;
+use crate::hal::prelude::*;
+use crate::hal::rcc;
+use crate::hal::spi;
+use crate::hal::stm32;
+
+use embedded_hal;
+use embedded_hal::digital::v2::OutputPin;
+
+type Spi1 = spi::Spi<
+    stm32::SPI1,
+    (
+        gpioa::PA5<gpio::Alternate<gpio::AF5>>,
+        gpioa::PA6<gpio::Alternate<gpio::AF5>>,
+        gpioa::PA7<gpio::Alternate<gpio::AF5>>,
+    ),
+>;
+
+type ChipSelect = gpioe::PE3<gpio::Output<gpio::PushPull>>;
+
+pub struct Accelerometer {
+    lis302dl: lis302dl::Lis302Dl<Spi1, ChipSelect>,
+}
+
+impl Accelerometer {
+    pub fn new(
+        gpioa: gpioa::Parts,
+        gpioe: gpioe::Parts,
+        spi1: stm32::SPI1,
+        clocks: rcc::Clocks,
+    ) -> Self {
+        let sck = gpioa.pa5.into_alternate_af5().internal_pull_up(false);
+        let miso = gpioa.pa6.into_alternate_af5().internal_pull_up(false);
+        let mosi = gpioa.pa7.into_alternate_af5().internal_pull_up(false);
+
+        let spi_mode = spi::Mode {
+            polarity: spi::Polarity::IdleLow,
+            phase: spi::Phase::CaptureOnFirstTransition,
+        };
+
+        let spi = spi::Spi::spi1(spi1, (sck, miso, mosi), spi_mode, 10.mhz().into(), clocks);
+
+        let mut chip_select = gpioe.pe3.into_push_pull_output();
+        chip_select.set_high().ok();
+
+        let config = lis302dl::Config {
+            scale: lis302dl::Scale::PlusMinus8G,
+            ..Default::default()
+        };
+        let lis302dl = lis302dl::Lis302Dl::new(spi, chip_select, config);
+
+        Self { lis302dl }
+    }
+}
+
+impl accelerometer::RawAccelerometer<accelerometer::vector::I8x3> for Accelerometer {
+    type Error = spi::Error;
+    fn accel_raw(
+        &mut self,
+    ) -> Result<accelerometer::vector::I8x3, accelerometer::Error<Self::Error>> {
+        self.lis302dl.accel_raw()
+    }
+}
+
+impl accelerometer::Accelerometer for Accelerometer {
+    type Error = spi::Error;
+    fn sample_rate(&mut self) -> Result<f32, accelerometer::Error<Self::Error>> {
+        self.lis302dl.sample_rate()
+    }
+
+    fn accel_norm(
+        &mut self,
+    ) -> Result<accelerometer::vector::F32x3, accelerometer::Error<Self::Error>> {
+        self.lis302dl.accel_norm()
+    }
+}

--- a/src/led.rs
+++ b/src/led.rs
@@ -45,6 +45,10 @@ impl Leds {
             leds: [top.into(), left.into(), right.into(), bottom.into()],
         }
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<Led> {
+        self.leds.iter_mut()
+    }
 }
 
 impl core::ops::Deref for Leds {
@@ -113,20 +117,20 @@ ctor!(LD3, LD4, LD5, LD6);
 impl Led {
     /// Turns the LED off
     pub fn off(&mut self) {
-        self.pin.set_low();
+        self.pin.set_low().ok();
     }
 
     /// Turns the LED on
     pub fn on(&mut self) {
-        self.pin.set_high();
+        self.pin.set_high().ok();
     }
 
     /// Toggles the LED
     pub fn toggle(&mut self) {
         if let Ok(true) = self.pin.is_low() {
-            self.pin.set_high();
+            self.pin.set_high().ok();
         } else {
-            self.pin.set_low();
+            self.pin.set_low().ok();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ pub use crate::hal::*;
 pub use cortex_m::*;
 pub use cortex_m_rt::*;
 
+pub mod accelerometer;
 pub mod led;


### PR DESCRIPTION
This example connects to the accelerometer and lights up the LEDs for the side that is higher.
![accelerometer_demo](https://user-images.githubusercontent.com/3506681/83598505-b905fa00-a51e-11ea-82ec-062301678311.gif)

