### PR TITLE
Fix LED pinouts per ST UM1472

### DIFF
--- a/examples/mems.rs
+++ b/examples/mems.rs
@@ -55,25 +55,25 @@ fn main() -> ! {
                 acceleration.z,
             );
 
-            for led in leds.iter_mut() {
-                led.off();
-            }
-
-            // x+ red
-            // x- green
-            // y+ orange
-            // y- blue
-
-            if acceleration.y > 0.0 {
-                leds[LedColor::Orange].on();
-            } else {
-                leds[LedColor::Blue].on();
-            }
+            // x+ orange
+            // x- blue
+            // y+ red
+            // y- green
 
             if acceleration.x > 0.0 {
+                leds[LedColor::Orange].on();
+                leds[LedColor::Blue].off();
+            } else {
+                leds[LedColor::Blue].on();
+                leds[LedColor::Orange].off();
+            }
+
+            if acceleration.y > 0.0 {
                 leds[LedColor::Red].on();
+                leds[LedColor::Green].off();
             } else {
                 leds[LedColor::Green].on();
+                leds[LedColor::Red].off();
             }
         }
     }

--- a/src/led.rs
+++ b/src/led.rs
@@ -5,27 +5,27 @@ use crate::hal::prelude::*;
 use crate::hal::gpio::gpiod::{self, PD, PD12, PD13, PD14, PD15};
 use crate::hal::gpio::{Output, PushPull};
 
+
+// For LED pinout see ST user manual:
+// [UM1472](https://www.st.com/resource/en/user_manual/um1472-discovery-kit-with-stm32f407vg-mcu-stmicroelectronics.pdf)
+
 /// Top LED (orange)
-pub type LD3 = PD12<Output<PushPull>>;
+pub type LD3 = PD13<Output<PushPull>>;
 
 /// Left LED (green)
-pub type LD4 = PD13<Output<PushPull>>;
+pub type LD4 = PD12<Output<PushPull>>;
 
 /// Right LED (red)
-pub type LD5 = PD15<Output<PushPull>>;
+pub type LD5 = PD14<Output<PushPull>>;
 
 /// Bottom LED (blue)
-pub type LD6 = PD14<Output<PushPull>>;
+pub type LD6 = PD15<Output<PushPull>>;
 
 /// User LED colors
 pub enum LedColor {
-    /// Green LED / LD4
-    Green,
-    /// Orange LED / LD3
     Orange,
-    /// Red LED / LD5
+    Green,
     Red,
-    /// Blue LED / LD6
     Blue,
 }
 
@@ -36,8 +36,8 @@ pub struct Leds {
 
 impl Leds {
     pub fn new(gpiod: gpiod::Parts) -> Self {
-        let top = gpiod.pd12.into_push_pull_output();
-        let left = gpiod.pd13.into_push_pull_output();
+        let top = gpiod.pd13.into_push_pull_output();
+        let left = gpiod.pd12.into_push_pull_output();
         let right = gpiod.pd14.into_push_pull_output();
         let bottom = gpiod.pd15.into_push_pull_output();
 


### PR DESCRIPTION
This PR is meant to correct a couple of the LED pin assignments.

According to [UM1472](https://www.st.com/resource/en/user_manual/um1472-discovery-kit-with-stm32f407vg-mcu-stmicroelectronics.pdf)

Correcting the assignments resulted in a couple changes in the use of the LED's now that the indexing was changed.

One additional change was to optimize/change the `mems` example such that it only turns off the LED's it needs to. The change of `X` and `Y` was because on my board, the tilting of the mems sensor did not correspond to the LED changes. By swapping the `X` and `Y` it cause the LED's to correlate with the direction the board was tilted.

Correct assignment for `STM32F4DISCOVERY Discovery kit` is
* LD3: orange LED is a user LED connected to the I/O PD13 
* LD4: green LED is a user LED connected to the I/O PD12 
* LD5: red LED is a user LED connected to the I/O PD14
* User LD6: blue LED is a user LED connected to the I/O PD15


One last note:
In order to build and test this code, I had to roll back the versions of the some of the dependencies. This should not have an impact on the assignment of the LED's but is questionable. Not sure if it is due the the version of rust I am using, vs needing nightly etc.

I tested the build using:
```
cargo 1.59.0 (49d8809dc 2022-02-10)
rustc 1.59.0 (9d1b2106e 2022-02-23)
```
