### PR TITLE
Fixed openocd_program.sh for Ubuntu where dash is used as default shell (/bin/sh)

### DIFF
--- a/openocd_program.sh
+++ b/openocd_program.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if (( $# != 1 )); then
+if [ $# != 1 ]; then
         echo "Usage:"
         echo "$0 <filename of firmware in ELF format>"
         exit 1


### PR DESCRIPTION
The existing condition doesn't work for me:

```bash
$ ./openocd_program.sh
./openocd_program.sh: 2: 0: not found
Open On-Chip Debugger 0.11.0
...
$
```

It's O.K. after the suggested fix:
```bash
$ ./openocd_program.sh
Usage:
./openocd_program.sh <filename of firmware in ELF format>
$
```

Tested on Ubuntu 22.04. I tested that the fix works for `sh` and `bash`.