### PR TITLE
Added a runner for newer Ubuntu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# Keep uncommented ONE of these two runners to make `cargo run` start a GDB session
+# Which option to pick depends on your system
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
 
 rustflags = [
   "-C", "link-arg=-Tlink.x",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,8 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "rust-lang.rust-analyzer",
-        "marus25.cortex-debug"
+        "marus25.cortex-debug",
+        "bungcip.better-toml"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []


### PR DESCRIPTION
- Added a runner for newer Ubuntu: See https://docs.rust-embedded.org/book/intro/install/linux.html. Still the existing runner is default one.
- Added the extension TOML to Cargo config. It's a preferred form since Rust 1.39, see https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure.
It also allows automatic highlighting in VSCode (https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml):

![image](https://user-images.githubusercontent.com/12584138/200182094-bd0b3708-ba33-4407-a859-b43477e6a15a.png)
