### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It also contains a (non-removable) capable ST-Link V2 debugging interface.
 Programming
 -----------
 
-Several methods for programming exist. If the ST-Link on your board has a recent firmware (can be updated e.g. via [ST-LINK utility](https://www.st.com/en/development-tools/stsw-link004.html)), we recommend the use of [cargo-embed](https://github.com/probe-rs/cargo-embed):
+Several methods for programming exist. If the ST-Link on your board has a recent firmware (can be updated e.g. via [ST-LINK utility](https://www.st.com/en/development-tools/stsw-link004.html)), we recommend the use of [cargo-embed](https://github.com/probe-rs/probe-rs/tree/master/cargo-embed):
 
 ```sh
 cargo embed --example=mems


### PR DESCRIPTION
cargo-embed is now part of the main probe-rs repository at https://github.com/probe-rs/probe-rs. location in probe-rs is https://github.com/probe-rs/probe-rs/tree/master/cargo-embed