### PR TITLE
Fix example build errors

### DIFF
--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -42,7 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let mut disp: TerminalMode<_, _> =
+            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -9,7 +9,7 @@ use panic_halt as _;
 
 use stm32f407g_disc as board;
 
-use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder};
+use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
 use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
 
@@ -42,8 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_, _> =
-            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let interface = I2CDIBuilder::new().init(i2c);
+        let mut disp: TerminalMode<_, _> = Builder::new().connect(interface).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -42,7 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let mut disp: TerminalMode<_, _> =
+            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -9,7 +9,7 @@ use panic_halt as _;
 
 use stm32f407g_disc as board;
 
-use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder};
+use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
 use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
 
@@ -42,8 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_, _> =
-            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let interface = I2CDIBuilder::new().init(i2c);
+        let mut disp: TerminalMode<_, _> = Builder::new().connect(interface).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);


### PR DESCRIPTION
I am trying to get set up using this BSP crate.

When I try a clean `cargo build --examples`, I got the following errors:
```
error[E0107]: struct takes 2 generic arguments but 1 generic argument was supplied
   --> examples/i2c_hal_ssd1306helloworld.rs:45:23
    |
45  |         let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
    |                       ^^^^^^^^^^^^ - supplied 1 generic argument
    |                       |
    |                       expected 2 generic arguments
```
and
```
error[E0599]: no method named `with_i2c_addr` found for struct `Builder` in the current scope
  --> examples/i2c_hal_ssd1306alphabeter.rs:45:56
   |
45 |         let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
   |                                                        ^^^^^^^^^^^^^ method not found in `Builder`
```

It seems that this was the old API for the `ssd1306` crate: https://docs.rs/ssd1306/0.3.1/ssd1306/index.html

The `Cargo.toml`-specified `ssd1306=0.5.2` versions uses a slightly different API: https://docs.rs/ssd1306/0.5.2/ssd1306/index.html. I have fixed this in this PR. I do not have a `ssd1306` display to test this out, so this is just to fix the build errors.