### PR TITLE
Bump `stm32f4xx-hal` version to `0.10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.2"
 [dependencies.stm32f4xx-hal]
 default-features = false
 features = ["rt", "stm32f407"]
-version = "0.9.0"
+version = "0.10.0"
 
 [dev-dependencies]
 ssd1306 = "0.5.2"

--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -42,7 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let mut disp: TerminalMode<_, _> =
+            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -9,7 +9,7 @@ use panic_halt as _;
 
 use stm32f407g_disc as board;
 
-use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder};
+use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
 use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
 
@@ -42,8 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_, _> =
-            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let interface = I2CDIBuilder::new().init(i2c);
+        let mut disp: TerminalMode<_, _> = Builder::new().connect(interface).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -42,7 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_> = Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let mut disp: TerminalMode<_, _> =
+            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -9,7 +9,7 @@ use panic_halt as _;
 
 use stm32f407g_disc as board;
 
-use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder};
+use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
 use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
 
@@ -42,8 +42,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
-        let mut disp: TerminalMode<_, _> =
-            Builder::new().with_i2c_addr(0x3c).connect_i2c(i2c).into();
+        let interface = I2CDIBuilder::new().init(i2c);
+        let mut disp: TerminalMode<_, _> = Builder::new().connect(interface).into();
 
         // Set display rotation to 180 degrees
         let _ = disp.set_rotation(DisplayRotation::Rotate180);

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -9,15 +9,12 @@ use crate::hal::rcc;
 use crate::hal::spi;
 use crate::hal::stm32;
 
-use embedded_hal;
-use embedded_hal::digital::v2::OutputPin;
-
 type Spi1 = spi::Spi<
     stm32::SPI1,
     (
-        gpioa::PA5<gpio::Alternate<gpio::AF5>>,
-        gpioa::PA6<gpio::Alternate<gpio::AF5>>,
-        gpioa::PA7<gpio::Alternate<gpio::AF5>>,
+        gpioa::PA5<gpio::Alternate<{ gpio::AF5 }>>,
+        gpioa::PA6<gpio::Alternate<{ gpio::AF5 }>>,
+        gpioa::PA7<gpio::Alternate<{ gpio::AF5 }>>,
     ),
     spi::TransferModeNormal,
 >;
@@ -35,19 +32,19 @@ impl Accelerometer {
         spi1: stm32::SPI1,
         clocks: rcc::Clocks,
     ) -> Self {
-        let sck = gpioa.pa5.into_alternate_af5().internal_pull_up(false);
-        let miso = gpioa.pa6.into_alternate_af5().internal_pull_up(false);
-        let mosi = gpioa.pa7.into_alternate_af5().internal_pull_up(false);
+        let sck = gpioa.pa5.into_alternate().internal_pull_up(false);
+        let miso = gpioa.pa6.into_alternate().internal_pull_up(false);
+        let mosi = gpioa.pa7.into_alternate().internal_pull_up(false);
 
         let spi_mode = spi::Mode {
             polarity: spi::Polarity::IdleLow,
             phase: spi::Phase::CaptureOnFirstTransition,
         };
 
-        let spi = spi::Spi::spi1(spi1, (sck, miso, mosi), spi_mode, 10.mhz().into(), clocks);
+        let spi = spi::Spi::new(spi1, (sck, miso, mosi), spi_mode, 10.mhz().into(), clocks);
 
         let mut chip_select = gpioe.pe3.into_push_pull_output();
-        chip_select.set_high().ok();
+        chip_select.set_high();
 
         let config = lis302dl::Config {
             scale: lis302dl::Scale::PlusMinus8G,

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -41,7 +41,7 @@ impl Accelerometer {
             phase: spi::Phase::CaptureOnFirstTransition,
         };
 
-        let spi = spi::Spi::new(spi1, (sck, miso, mosi), spi_mode, 10.mhz().into(), clocks);
+        let spi = spi::Spi::new(spi1, (sck, miso, mosi), spi_mode, 10.mhz(), clocks);
 
         let mut chip_select = gpioe.pe3.into_push_pull_output();
         chip_select.set_high();

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -19,6 +19,7 @@ type Spi1 = spi::Spi<
         gpioa::PA6<gpio::Alternate<gpio::AF5>>,
         gpioa::PA7<gpio::Alternate<gpio::AF5>>,
     ),
+    spi::TransferModeNormal,
 >;
 
 type ChipSelect = gpioe::PE3<gpio::Output<gpio::PushPull>>;

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,10 +1,7 @@
 //! On-board user LEDs
 
-use crate::hal::prelude::*;
-
 use crate::hal::gpio::gpiod::{self, PD, PD12, PD13, PD14, PD15};
 use crate::hal::gpio::{Output, PushPull};
-
 
 // For LED pinout see ST user manual:
 // [UM1472](https://www.st.com/resource/en/user_manual/um1472-discovery-kit-with-stm32f407vg-mcu-stmicroelectronics.pdf)
@@ -104,7 +101,7 @@ macro_rules! ctor {
 			impl Into<Led> for $ldx {
 				fn into(self) -> Led {
 					Led {
-						pin: self.downgrade(),
+						pin: self.erase_number(),
 					}
 				}
 			}

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,6 +1,6 @@
 //! On-board user LEDs
 
-use crate::hal::gpio::gpiod::{self, PD, PD12, PD13, PD14, PD15};
+use crate::hal::gpio::gpiod::{self, PDn, PD12, PD13, PD14, PD15};
 use crate::hal::gpio::{Output, PushPull};
 
 // For LED pinout see ST user manual:
@@ -92,7 +92,7 @@ impl core::ops::IndexMut<LedColor> for Leds {
 
 /// One of the on-board user LEDs
 pub struct Led {
-    pin: PD<Output<PushPull>>,
+    pin: PDn<Output<PushPull>>,
 }
 
 macro_rules! ctor {

--- a/src/led.rs
+++ b/src/led.rs
@@ -114,20 +114,16 @@ ctor!(LD3, LD4, LD5, LD6);
 impl Led {
     /// Turns the LED off
     pub fn off(&mut self) {
-        self.pin.set_low().ok();
+        self.pin.set_low();
     }
 
     /// Turns the LED on
     pub fn on(&mut self) {
-        self.pin.set_high().ok();
+        self.pin.set_high();
     }
 
     /// Toggles the LED
     pub fn toggle(&mut self) {
-        if let Ok(true) = self.pin.is_low() {
-            self.pin.set_high().ok();
-        } else {
-            self.pin.set_low().ok();
-        }
+        self.pin.toggle();
     }
 }


### PR DESCRIPTION
Updates the function calls according to the `stm32f4xx-hal` API changes.