### PR TITLE
Remove unused`panic-itm` specification from Cargo.toml `dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,3 @@ debug = true
 debug = true
 lto = true
 opt-level = "s"
-
-[dependencies.panic-itm]
-version = "0.4.2"


### PR DESCRIPTION
`panic-itm` was specified both in `dependencies` and in `dev-dependencies` with similar versions. This merges the dependency specifications