### PR TITLE
Bump `stm32f4xx-hal` version to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ targets = ["thumbv7em-none-eabihf"]
 [dependencies]
 accelerometer = "0.11.0"
 cortex-m = "0.7.2"
-cortex-m-rt = "0.6.13"
+cortex-m-rt = "0.7.0"
 lis302dl = "0.1.0"
 
 [dependencies.embedded-hal]
@@ -35,7 +35,7 @@ version = "0.2"
 [dependencies.stm32f4xx-hal]
 default-features = false
 features = ["rt", "stm32f407"]
-version = "0.10.0"
+version = "0.17.0"
 
 [dev-dependencies]
 ssd1306 = "0.5.2"

--- a/examples/gpio_hal_blinky.rs
+++ b/examples/gpio_hal_blinky.rs
@@ -7,8 +7,8 @@ use panic_halt as _;
 use stm32f407g_disc as board;
 
 use crate::board::{
-    hal::stm32,
-    hal::{delay::Delay, prelude::*},
+    hal::pac,
+    hal::prelude::*,
     led::{LedColor, Leds},
 };
 
@@ -18,7 +18,7 @@ use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         let gpiod = p.GPIOD.split();
 
         // Initialize on-board LEDs
@@ -28,10 +28,10 @@ fn main() -> ! {
         let rcc = p.RCC.constrain();
 
         // Configure clock to 168 MHz (i.e. the maximum) and freeze it
-        let clocks = rcc.cfgr.sysclk(168.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(168.MHz()).freeze();
 
         // Get delay provider
-        let mut delay = Delay::new(cp.SYST, clocks);
+        let mut delay = cp.SYST.delay(&clocks);
 
         loop {
             // Turn LEDs on one after the other with 500ms delay between them

--- a/examples/gpio_hal_busy_blinky.rs
+++ b/examples/gpio_hal_busy_blinky.rs
@@ -7,7 +7,7 @@ use stm32f407g_disc as board;
 
 use crate::board::{
     hal::prelude::*,
-    hal::stm32,
+    hal::pac,
     led::{LedColor, Leds},
 };
 
@@ -15,7 +15,7 @@ use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         let gpiod = p.GPIOD.split();
 
         // Initialize on-board LEDs

--- a/examples/i2c_hal_ssd1306alphabeter.rs
+++ b/examples/i2c_hal_ssd1306alphabeter.rs
@@ -7,39 +7,27 @@
 
 use panic_halt as _;
 
+use core::fmt::Write;
+
 use stm32f407g_disc as board;
 
 use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
-use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
-
-use core::fmt::Write;
+use crate::board::{hal::i2c::*, hal::pac, hal::prelude::*};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         let gpiob = p.GPIOB.split();
         let rcc = p.RCC.constrain();
 
         // Set up the clocks, going too fast exhibits some problem so let's take it slow for now
-        let clocks = rcc.cfgr.sysclk(40.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(40.MHz()).freeze();
 
-        // Set up the SCL pin of the I2C bus at PB6
-        let scl = gpiob
-            .pb6
-            .into_alternate_af4()
-            .internal_pull_up(true)
-            .set_open_drain();
-
-        // Set up the SDA pin of the I2C bus at PB7
-        let sda = gpiob
-            .pb7
-            .into_alternate_af4()
-            .internal_pull_up(true)
-            .set_open_drain();
-
-        // Setup I2C1 using the above defined pins at 400kHz bitrate (fast mode)
-        let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
+        // Setup I2C1 using PB6/PB7 at 400kHz bitrate (fast mode)
+        let scl = gpiob.pb6;
+        let sda = gpiob.pb7;
+        let i2c = I2c::new(p.I2C1, (scl, sda), 400.kHz(), &clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
         let interface = I2CDIBuilder::new().init(i2c);

--- a/examples/i2c_hal_ssd1306helloworld.rs
+++ b/examples/i2c_hal_ssd1306helloworld.rs
@@ -9,37 +9,25 @@ use panic_halt as _;
 
 use stm32f407g_disc as board;
 
+use core::fmt::Write;
+
 use ssd1306::{displayrotation::DisplayRotation, mode::TerminalMode, Builder, I2CDIBuilder};
 
-use crate::board::{hal::i2c::*, hal::prelude::*, hal::stm32};
-
-use core::fmt::Write;
+use crate::board::{hal::i2c::*, hal::pac, hal::prelude::*};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         let gpiob = p.GPIOB.split();
         let rcc = p.RCC.constrain();
 
         // Set up the clocks, going too fast exhibits some problem so let's take it slow for now
-        let clocks = rcc.cfgr.sysclk(40.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(40.MHz()).freeze();
 
-        // Set up the SCL pin of the I2C bus at PB6
-        let scl = gpiob
-            .pb6
-            .into_alternate_af4()
-            .internal_pull_up(true)
-            .set_open_drain();
-
-        // Set up the SDA pin of the I2C bus at PB7
-        let sda = gpiob
-            .pb7
-            .into_alternate_af4()
-            .internal_pull_up(true)
-            .set_open_drain();
-
-        // Setup I2C1 using the above defined pins at 400kHz bitrate (fast mode)
-        let i2c = I2c::i2c1(p.I2C1, (scl, sda), 400.khz(), clocks);
+        // Setup I2C1 using PB6/PB7 at 400kHz bitrate (fast mode)
+        let scl = gpiob.pb6;
+        let sda = gpiob.pb7;
+        let i2c = I2c::new(p.I2C1, (scl, sda), 400.kHz(), &clocks);
 
         // Set up the SSD1306 display at I2C address 0x3c
         let interface = I2CDIBuilder::new().init(i2c);

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -9,29 +9,29 @@
 #![no_main]
 #![no_std]
 
+extern crate embedded_hal as hal;
 extern crate panic_itm;
 extern crate stm32f407g_disc as board;
-extern crate embedded_hal as hal;
 
+use board::hal::pac;
 use board::hal::prelude::*;
-use board::hal::stm32;
 
 use cortex_m::{iprintln, Peripherals};
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-	if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
-	    // Constrain clock registers
-	    let rcc = p.RCC.constrain();
-	    // Configure clock to 168 MHz (i.e. the maximum) and freeze it
-	    rcc.cfgr.sysclk(168.mhz()).freeze();
+    if let (Some(p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
+        // Constrain clock registers
+        let rcc = p.RCC.constrain();
+        // Configure clock to 168 MHz (i.e. the maximum) and freeze it
+        rcc.cfgr.sysclk(168.MHz()).freeze();
 
-	    let mut itm = cp.ITM;
-	    let stim = &mut itm.stim[0];
+        let mut itm = cp.ITM;
+        let stim = &mut itm.stim[0];
 
-	    iprintln!(stim, "Hello, world!");
-	}
+        iprintln!(stim, "Hello, world!");
+    }
 
     loop {}
 }

--- a/examples/mems.rs
+++ b/examples/mems.rs
@@ -12,7 +12,7 @@ use stm32f407g_disc as board;
 use cortex_m_rt::entry;
 
 use board::hal::prelude::*;
-use board::hal::stm32;
+use board::hal::pac;
 use board::led::{LedColor, Leds};
 
 use cortex_m::iprintln;
@@ -23,7 +23,7 @@ use accelerometer::Accelerometer;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         let gpioa = p.GPIOA.split();
         let gpiod = p.GPIOD.split();
         let gpioe = p.GPIOE.split();
@@ -36,7 +36,7 @@ fn main() -> ! {
         let rcc = p.RCC.constrain();
 
         // Configure clock to 168 MHz (i.e. the maximum) and freeze it
-        let clocks = rcc.cfgr.sysclk(168.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(168.MHz()).freeze();
 
         let mut accelerometer =
             board::accelerometer::Accelerometer::new(gpioa, gpioe, p.SPI1, clocks);

--- a/examples/mems.rs
+++ b/examples/mems.rs
@@ -11,8 +11,8 @@ use stm32f407g_disc as board;
 
 use cortex_m_rt::entry;
 
-use board::hal::prelude::*;
 use board::hal::pac;
+use board::hal::prelude::*;
 use board::led::{LedColor, Leds};
 
 use cortex_m::iprintln;
@@ -55,25 +55,25 @@ fn main() -> ! {
                 acceleration.z,
             );
 
-            // x+ orange
-            // x- blue
-            // y+ red
-            // y- green
+            // x+ red
+            // x- green
+            // y+ orange
+            // y- blue
 
             if acceleration.x > 0.0 {
-                leds[LedColor::Orange].on();
-                leds[LedColor::Blue].off();
-            } else {
-                leds[LedColor::Blue].on();
-                leds[LedColor::Orange].off();
-            }
-
-            if acceleration.y > 0.0 {
                 leds[LedColor::Red].on();
                 leds[LedColor::Green].off();
             } else {
                 leds[LedColor::Green].on();
                 leds[LedColor::Red].off();
+            }
+
+            if acceleration.y > 0.0 {
+                leds[LedColor::Orange].on();
+                leds[LedColor::Blue].off();
+            } else {
+                leds[LedColor::Blue].on();
+                leds[LedColor::Orange].off();
             }
         }
     }

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -13,31 +13,32 @@ use stm32f407g_disc as board;
 use nb::block;
 
 use crate::board::{
+    hal::pac,
     hal::prelude::*,
-    hal::stm32,
-    serial::{config::Config, Serial},
+    hal::serial::{config::Config, Serial},
 };
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         let gpioa = p.GPIOA.split();
         let rcc = p.RCC.constrain();
-        let clocks = rcc.cfgr.sysclk(48.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
 
         // USART2 at PA2 (TX) and PA3(RX) are connected to ST-Link
         // (well, not really, you're supposed to wire them yourself!)
-        let tx = gpioa.pa2.into_alternate_af7();
-        let rx = gpioa.pa3.into_alternate_af7();
+        let tx = gpioa.pa2;
+        let rx = gpioa.pa3;
 
         // Set up USART 2 configured pins and a baudrate of 115200 baud
-        let serial = Serial::usart2(
+        let serial = Serial::new(
             p.USART2,
             (tx, rx),
             Config::default().baudrate(115_200.bps()),
-            clocks,
+            &clocks,
         )
-        .unwrap();
+        .unwrap()
+        .with_u8_data();
 
         // Separate out the sender and receiver of the serial port
         let (mut tx, mut rx) = serial.split();

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -4,20 +4,12 @@ use lis302dl;
 use crate::hal::gpio;
 use crate::hal::gpio::gpioa;
 use crate::hal::gpio::gpioe;
+use crate::hal::pac;
 use crate::hal::prelude::*;
 use crate::hal::rcc;
 use crate::hal::spi;
-use crate::hal::stm32;
 
-type Spi1 = spi::Spi<
-    stm32::SPI1,
-    (
-        gpioa::PA5<gpio::Alternate<{ gpio::AF5 }>>,
-        gpioa::PA6<gpio::Alternate<{ gpio::AF5 }>>,
-        gpioa::PA7<gpio::Alternate<{ gpio::AF5 }>>,
-    ),
-    spi::TransferModeNormal,
->;
+type Spi1 = spi::Spi<pac::SPI1>;
 
 type ChipSelect = gpioe::PE3<gpio::Output<gpio::PushPull>>;
 
@@ -29,19 +21,19 @@ impl Accelerometer {
     pub fn new(
         gpioa: gpioa::Parts,
         gpioe: gpioe::Parts,
-        spi1: stm32::SPI1,
+        spi1: pac::SPI1,
         clocks: rcc::Clocks,
     ) -> Self {
-        let sck = gpioa.pa5.into_alternate().internal_pull_up(false);
-        let miso = gpioa.pa6.into_alternate().internal_pull_up(false);
-        let mosi = gpioa.pa7.into_alternate().internal_pull_up(false);
+        let sck = gpioa.pa5.internal_pull_up(false);
+        let miso = gpioa.pa6.internal_pull_up(false);
+        let mosi = gpioa.pa7.internal_pull_up(false);
 
         let spi_mode = spi::Mode {
             polarity: spi::Polarity::IdleLow,
             phase: spi::Phase::CaptureOnFirstTransition,
         };
 
-        let spi = spi::Spi::new(spi1, (sck, miso, mosi), spi_mode, 10.mhz(), clocks);
+        let spi = spi::Spi::new(spi1, (sck, miso, mosi), spi_mode, 10.MHz(), &clocks);
 
         let mut chip_select = gpioe.pe3.into_push_pull_output();
         chip_select.set_high();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,9 @@
 
 pub use stm32f4xx_hal as hal;
 
-pub use crate::hal::stm32::interrupt::*;
-pub use crate::hal::stm32::Interrupt as interrupt;
-pub use crate::hal::stm32::Peripherals;
-pub use crate::hal::stm32::*;
-pub use crate::hal::*;
-pub use cortex_m::*;
-pub use cortex_m_rt::*;
+pub use crate::hal::pac::interrupt::*;
+pub use crate::hal::pac::Interrupt;
+pub use crate::hal::pac::Peripherals;
 
 pub mod accelerometer;
 pub mod led;


### PR DESCRIPTION
Updates the function calls according to the `stm32f4xx-hal` API changes.

Tested by building all examples, as well as running the following examples on-device:
* `gpio_hal_blinky`
* `mems`

I checked that the behavior of these examples matched the behavior when running `cargo embed` on `master`.

I also fixed an issue where the `mems` example uses the incorrect LEDs. Based on my local testing, the mapping should be:
* `x>0`: red
* `x<0`: green
* `y>0`: orange
* `y<0`: blue
Note: I have a [`STM32F407G-DISC1` board](https://www.st.com/en/evaluation-tools/stm32f4discovery.html), which is the same currently linked in the README.md. The `gpio_hal_blinky` LED order looks good to me.